### PR TITLE
Push stats to influxdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ various levels of detail in the aggregated data are available from jobHarvest.
 Requirements
 ------------
 
-jobHarvest requires pyslurm be available on the aggregation host in order to track the life cycle of slurm jobs.
+jobHarvest requires pyslurm be available on the aggregation host in order to track the life cycle of slurm jobs. influxdb-client is required to enable writing to InfluxDB.
 
 How it Works
 ------------
@@ -31,3 +31,13 @@ data is transferred by sending serialised python objects over simple TCP connect
 
 jobHarvest transparently handles client and server process disconnections and restarts (eg. OSS reboots).
 
+Writing to InfluxDB
+-------------------
+Creating an config file at `/root/.jobHarvest.influx` containing
+
+    http://server_address:port
+    org_name
+    bucket_name
+    token
+
+will enable writing to InfluxDB.

--- a/jobHarvest.py
+++ b/jobHarvest.py
@@ -40,7 +40,7 @@ dryrun = 0
 secretFile = '/root/.lustreHarvest.secret'
 
 # influx credentials file (if file doesn't exist, influx is disabled):
-influxConfigFile = '/root/jobHarvest.influx'
+influxConfigFile = '/root/.jobHarvest.influx'
 # Template:
 #
 # http://server_address:port

--- a/jobHarvest.py
+++ b/jobHarvest.py
@@ -1140,17 +1140,17 @@ def influxWrite(jSum, jobArrayMap):
 
    for jobid in jSum:
       for fs in jSum[jobid]:
-         for measurement in jSum[jobid][fs]:
+         for server in jSum[jobid][fs]:
 
             # Copy the fields and pop 'snapshot_time'
             # This prevents the original dict from being modified
-            fields = copy.deepcopy(jSum[jobid][fs][measurement])
+            fields = copy.deepcopy(jSum[jobid][fs][server])
             t = fields.pop('snapshot_time')
 
             data = [
                {
-                  'measurement': measurement,
-                  'tags': {'job': jobArrayMap[jobid], 'fs': fs},
+                  'measurement': 'lustre',
+                  'tags': {'job': jobArrayMap[jobid], 'fs': fs, 'server': server},
                   'fields': fields,
                   'time': t,
                }

--- a/jobHarvest.py
+++ b/jobHarvest.py
@@ -1150,7 +1150,7 @@ def influxWrite(r, jobArrayMap):
             data = [
                {
                   'measurement': measurement,
-                  'tags': {'job': jobArrayMap[jobid]},
+                  'tags': {'job': jobArrayMap[jobid], 'fs': fs},
                   'fields': fields,
                   'time': t,
                }

--- a/jobHarvest.py
+++ b/jobHarvest.py
@@ -970,7 +970,7 @@ def serverCode( serverName, port ):
 
       # Write data to InfluxDB
       if influxConfig is not None and newData:
-         influxWrite(r, jobArrayMap)
+         influxWrite(jSum, jobArrayMap)
          newData = False
 
 
@@ -1123,7 +1123,7 @@ def readInfluxConfig():
       influxConfig = None
 
 
-def influxWrite(r, jobArrayMap):
+def influxWrite(jSum, jobArrayMap):
    from influxdb_client import InfluxDBClient
 
    print(f"writing data to {influxConfig['server']}")
@@ -1138,13 +1138,13 @@ def influxWrite(r, jobArrayMap):
 
    write_api = client.write_api()
 
-   for jobid in r:
-      for fs in r[jobid]:
-         for measurement in r[jobid][fs]:
+   for jobid in jSum:
+      for fs in jSum[jobid]:
+         for measurement in jSum[jobid][fs]:
 
             # Copy the fields and pop 'snapshot_time'
             # This prevents the original dict from being modified
-            fields = copy.deepcopy(r[jobid][fs][measurement])
+            fields = copy.deepcopy(jSum[jobid][fs][measurement])
             t = fields.pop('snapshot_time')
 
             data = [


### PR DESCRIPTION
Adds new feature: pushing stats to an influxdb server.

After each cycle, the `jSum` dict is written to the server using the influxdb-client library.
