### PR TITLE
Fix old data being sent to influx

### DIFF
--- a/jobHarvest.py
+++ b/jobHarvest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -u
+#!/usr/bin/env python3
 
 # read OST/MDT lustre job_stats
 #

--- a/jobHarvest.py
+++ b/jobHarvest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3 -u
 
 # read OST/MDT lustre job_stats
 #


### PR DESCRIPTION
Old data, in excess of Influx's retention period, was being sent to Influx because all of jSum was being sent at every iteration. This was incorrect behaviour.

This change calculates the new updates to jSum and only sends those changes. This fixes Influx's warnings of points older than the retention period being sent, as well as eliminates the unnecessary write volume.